### PR TITLE
build with primitive 0.8

### DIFF
--- a/bytehash.cabal
+++ b/bytehash.cabal
@@ -30,7 +30,7 @@ library
   build-depends:
     , base >=4.12 && <5
     , byte-order >=0.1.2 && <0.2
-    , primitive >=0.7 && <0.8
+    , primitive >=0.7 && <0.9
     , primitive-unlifted >=0.1.2 && <0.2
     , byteslice >=0.2.1 && <0.3
     , entropy >=0.4.1.5 && <0.5


### PR DESCRIPTION
```
❯ cabal build --constraint="primitive == 0.8.0.0" --allow-newer=byte-order:primitive --allow-newer=primitive-unlifted:primitive --allow-newer=byteslice:primitive --allow-newer=tuples:primitive --allow-newer=run-st:primitive --allow-newer=primitive-addr:primitive --allow-newer=wide-word:primitive --allow-newer=primitive-unaligned:primitive
Resolving dependencies...
Build profile: -w ghc-9.4.4 -O1
In order, the following will be built (use -v for more details):
 - byte-order-0.1.3.0 (lib) (requires download & build)
 - entropy-0.4.1.10 (lib:entropy) (requires download & build)
 - bytehash-0.1.0.0 (lib) (first run)
Downloading  byte-order-0.1.3.0
Downloaded   byte-order-0.1.3.0
Downloading  entropy-0.4.1.10
Starting     byte-order-0.1.3.0 (lib)
Downloaded   entropy-0.4.1.10
Starting     entropy-0.4.1.10 (all, legacy fallback)
Building     byte-order-0.1.3.0 (lib)
Installing   byte-order-0.1.3.0 (lib)
Completed    byte-order-0.1.3.0 (lib)
Building     entropy-0.4.1.10 (all, legacy fallback)
Installing   entropy-0.4.1.10 (all, legacy fallback)
Completed    entropy-0.4.1.10 (all, legacy fallback)
Configuring library for bytehash-0.1.0.0..
Preprocessing library for bytehash-0.1.0.0..
Building library for bytehash-0.1.0.0..
[1 of 4] Compiling Data.Bytes.Hash  ( src/Data/Bytes/Hash.hs, /home/chessai/haskell/bytehash/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytehash-0.1.0.0/build/Data/Bytes/Hash.o, /home/chessai/haskell/bytehash/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytehash-0.1.0.0/build/Data/Bytes/Hash.dyn_o )

src/Data/Bytes/Hash.hs:29:1: warning: [-Wunused-imports]
    The import of ‘.&., .|., unsafeShiftL’
    from module ‘Data.Bits’ is redundant
   |
29 | import Data.Bits ((.&.),(.|.),unsafeShiftL,unsafeShiftR)
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/Bytes/Hash.hs:31:34: warning: [-Wunused-imports]
    The import of ‘sizeofByteArray’
    from module ‘Data.Primitive’ is redundant
   |
31 | import Data.Primitive (ByteArray,sizeofByteArray,indexByteArray)
   |                                  ^^^^^^^^^^^^^^^

src/Data/Bytes/Hash.hs:33:1: warning: [-Wunused-imports]
    The import of ‘Data.Void’ is redundant
      except perhaps to import instances from ‘Data.Void’
    To import instances alone, use: import Data.Void()
   |
33 | import Data.Void (Void)
   | ^^^^^^^^^^^^^^^^^^^^^^^

src/Data/Bytes/Hash.hs:72:1: warning: [-Wunused-top-binds]
    Defined but not used: ‘wordSize’
   |
72 | wordSize = sizeOf (undefined :: Word)
   | ^^^^^^^^

src/Data/Bytes/Hash.hs:76:1: warning: [-Wunused-top-binds]
    Defined but not used: ‘byteSwap’
   |
76 | byteSwap (W# w) = W# (Exts.byteSwap# w)
   | ^^^^^^^^
[2 of 4] Compiling Data.Bytes.HashMap.Internal ( src/Data/Bytes/HashMap/Internal.hs, /home/chessai/haskell/bytehash/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytehash-0.1.0.0/build/Data/Bytes/HashMap/Internal.o, /home/chessai/haskell/bytehash/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytehash-0.1.0.0/build/Data/Bytes/HashMap/Internal.dyn_o )
[3 of 4] Compiling Data.Bytes.HashMap ( src/Data/Bytes/HashMap.hs, /home/chessai/haskell/bytehash/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytehash-0.1.0.0/build/Data/Bytes/HashMap.o, /home/chessai/haskell/bytehash/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytehash-0.1.0.0/build/Data/Bytes/HashMap.dyn_o )

src/Data/Bytes/HashMap.hs:59:1: warning: [-Wunused-imports]
    The import of ‘Data.Bits’ is redundant
      except perhaps to import instances from ‘Data.Bits’
    To import instances alone, use: import Data.Bits()
   |
59 | import Data.Bits ((.&.),complement)
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/Bytes/HashMap.hs:70:1: warning: [-Wunused-imports]
    The import of ‘Ptr’ from module ‘GHC.Exts’ is redundant
   |
70 | import GHC.Exts (Ptr(Ptr),Int(I#),SmallArray#,ByteArray#,ArrayArray#,Int#)
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/Bytes/HashMap.hs:82:1: warning: [-Wunused-imports]
    The qualified import of ‘Data.Primitive.Ptr’ is redundant
      except perhaps to import instances from ‘Data.Primitive.Ptr’
    To import instances alone, use: import Data.Primitive.Ptr()
   |
82 | import qualified Data.Primitive.Ptr as PM
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[4 of 4] Compiling Data.Bytes.HashMap.Word ( src/Data/Bytes/HashMap/Word.hs, /home/chessai/haskell/bytehash/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytehash-0.1.0.0/build/Data/Bytes/HashMap/Word.o, /home/chessai/haskell/bytehash/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytehash-0.1.0.0/build/Data/Bytes/HashMap/Word.dyn_o )
```