### PR TITLE
Bump bytestring upper bound

### DIFF
--- a/bytehash.cabal
+++ b/bytehash.cabal
@@ -37,7 +37,7 @@ library
   build-depends:
     , base                >=4.17.1  && <5
     , byteslice           >=0.2.1   && <0.3
-    , bytestring          >=0.10.8  && <0.12
+    , bytestring          >=0.10.8  && <0.13
     , containers          >=0.6
     , entropy             >=0.4.1.5 && <0.5
     , primitive           >=0.9     && <0.10


### PR DESCRIPTION
Tested with `stack --resolver=nightly-2024-06-22 test`.